### PR TITLE
Remove timeout argument from error logging,

### DIFF
--- a/dyndnsc/updater/dyndns2.py
+++ b/dyndnsc/updater/dyndns2.py
@@ -48,7 +48,7 @@ class UpdateProtocolDyndns2(UpdateProtocol):
                              auth=(self.userid, self.password), timeout=timeout)
         except (requests.exceptions.Timeout, requests.exceptions.ConnectionError) as exc:
             log.warning("an error occurred while updating IP at '%s'",
-                        timeout, self.updateUrl(), exc_info=exc)
+                        self.updateUrl(), exc_info=exc)
             return False
         else:
             r.close()


### PR DESCRIPTION
the string does not reference the timeout value
