### PR TITLE
make the dns resolver configurable for v4 or v6 (or both), update docs (try 2)

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -29,7 +29,7 @@ A basic example that should fit most peoples needs using the dyndns.com service:
               --updater-dyndns2-userid=bob \
               --updater-dyndns2-password=fub4r
 
-Updating an IPv6 adress when using `Miredo <http://www.remlab.net/miredo/>`_:
+Updating an IPv6 address when using `Miredo <http://www.remlab.net/miredo/>`_:
 
 .. code-block:: bash
 
@@ -37,7 +37,8 @@ Updating an IPv6 adress when using `Miredo <http://www.remlab.net/miredo/>`_:
               --updater-nsupdate-hostname test.nsupdate.info \
               --updater-nsupdate-userid   test.nsupdate.info \
               --updater-nsupdate-password xxxxxxxx \
-              --detector teredo
+              --detector teredo \
+              --dns dns,family:INET6
 
 Updating an IPv4 record on nsupdate.info with web based ip autodetection:
 
@@ -47,7 +48,8 @@ Updating an IPv4 record on nsupdate.info with web based ip autodetection:
               --updater-nsupdate-hostname test.nsupdate.info \
               --updater-nsupdate-userid   test.nsupdate.info \
               --updater-nsupdate-password xxxxxxxx \
-              --detector webcheck4,url:http://ipv4.nsupdate.info/myip,parser:plain
+              --detector webcheck4,url:http://ipv4.nsupdate.info/myip,parser:plain \
+              --dns dns,family:INET
 
 Updating an IPv6 record on nsupdate.info with interface based ip detection:
 
@@ -57,7 +59,8 @@ Updating an IPv6 record on nsupdate.info with interface based ip detection:
               --updater-nsupdate-hostname test.nsupdate.info \
               --updater-nsupdate-userid test.nsupdate.info \
               --updater-nsupdate-password xxxxxxxx \
-              --detector Iface,netmask:2001:470:1234:5678::/64,iface:eth0,family:INET6
+              --detector Iface,netmask:2001:470:1234:5678::/64,iface:eth0,family:INET6 \
+              --dns dns,family:INET6
 
 
 Passing parameters for IP detection

--- a/dyndnsc/cli.py
+++ b/dyndnsc/cli.py
@@ -42,6 +42,9 @@ def main():
     parser.add_argument("--detector", "--method", dest="detector",
                         help="method for detecting your IP (default webcheck)",
                         default='webcheck')
+    parser.add_argument("--dns", dest="dns",
+                        help="method for querying your IP from dns (default dns, ip v4 or v6)",
+                        default='dns')
     parser.add_argument("--loop", dest="loop",
                         help="loop forever (default is to update once)",
                         action="store_true", default=False)
@@ -82,6 +85,7 @@ def main():
 
     config = {}
     config['detector'] = args.detector
+    config['dns'] = args.dns
     config['sleeptime'] = int(args.sleeptime)
     config['updaters'] = updaters
 

--- a/dyndnsc/tests/detector/test_all.py
+++ b/dyndnsc/tests/detector/test_all.py
@@ -41,7 +41,7 @@ class TestIndividualDetectors(unittest.TestCase):
         import dyndnsc.detector.dns as ns
         NAME = "dns"
         self.assertTrue(NAME in ns.IPDetector_DNS.names())
-        detector = ns.IPDetector_DNS("localhost")
+        detector = ns.IPDetector_DNS(hostname_default="localhost")
         self.assertFalse(detector.can_detect_offline())
         self.assertEqual(None, detector.get_current_value())
         self.assertTrue(type(detector.detect()) in (type(None), str))

--- a/dyndnsc/tests/test_basic.py
+++ b/dyndnsc/tests/test_basic.py
@@ -23,6 +23,7 @@ class TestDynDnsc(unittest.TestCase):
         # create a dummy config:
         config = {}
         config['detector'] = "random"
+        config['dns'] = "dns"
         from dyndnsc.updater.manager import get_updater_class
         upd_cls = get_updater_class("dummy")(hostname="example.com")
         config['updaters'] = (upd_cls,)

--- a/dyndnsc/tests/updater/test_dyndns2.py
+++ b/dyndnsc/tests/updater/test_dyndns2.py
@@ -53,7 +53,7 @@ class TestDummyUpdater(unittest.TestCase):
         NAME = "dummy"
         theip = "127.0.0.1"
         self.assertEqual(NAME, dyndnsc.updater.dummy.UpdateProtocolDummy.configuration_key())
-        updater = dyndnsc.updater.dummy.UpdateProtocolDummy()
+        updater = dyndnsc.updater.dummy.UpdateProtocolDummy(hostname='localhost')
         self.assertEqual(str, type(updater.updateUrl()))
         self.assertEqual(theip, updater.update(theip))
 

--- a/dyndnsc/updater/dummy.py
+++ b/dyndnsc/updater/dummy.py
@@ -7,7 +7,8 @@ class UpdateProtocolDummy(UpdateProtocol):
 
     _updateurl = "http://localhost.nonexistant/nic/update"
 
-    def __init__(self, **kwargs):
+    def __init__(self, hostname, **kwargs):
+        self.hostname = hostname
         super(UpdateProtocolDummy, self).__init__()
 
     @staticmethod


### PR DESCRIPTION
made the dns detector less special: it can now get configured as any other detector.

this is most useful to give either family:INET or family:INET6 options, so dyndnsc will behave less confused
as before (when it regularly updated IPs, just because of comparing 2 different kinds of IPs).

there is also a hostname:host.name.to.query.com option (defaults to hostname from first updater so
one usually does not need to give it).

refactored some code into a separate parse_detector_opts function to avoid duplication.
