### PR TITLE
add socket-based IP detector, add test, update docs

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -59,7 +59,7 @@ Updating an IPv6 record on nsupdate.info with interface based ip detection:
               --updater-nsupdate-hostname test.nsupdate.info \
               --updater-nsupdate-userid test.nsupdate.info \
               --updater-nsupdate-password xxxxxxxx \
-              --detector Iface,netmask:2001:470:1234:5678::/64,iface:eth0,family:INET6 \
+              --detector socket,family:INET6 \
               --dns dns,family:INET6
 
 

--- a/dyndnsc/common/detect_ip.py
+++ b/dyndnsc/common/detect_ip.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+"""
+Detect IP v4 or v6 addresses the system uses to talk to outside world.
+
+Original code from https://github.com/vincentbernat/puppet-workstation/blob/master/modules/system/templates/network/ddns-updater.erb
+
+Refactored/modified by Thomas Waldmann to just detect the IP.
+"""
+
+from __future__ import print_function
+
+IPV4 = 'ipv4'
+IPV6_ANY = 'ipv6'
+IPV6_PUBLIC = 'ipv6_public'
+IPV6_TMP = 'ipv6_tmp'
+
+# reserved IPs for documentation/example purposes
+OUTSIDE_IPV4 = '192.0.2.1'
+OUTSIDE_IPV6 = '2001:db8::1'
+
+import errno
+import socket
+
+# Not everything is available in Python
+if not hasattr(socket, "IPV6_ADDR_PREFERENCES"):
+    socket.IPV6_ADDR_PREFERENCES = 72
+if not hasattr(socket, "IPV6_PREFER_SRC_TMP"):
+    socket.IPV6_PREFER_SRC_TMP = 1
+if not hasattr(socket, "IPV6_PREFER_SRC_PUBLIC"):
+    socket.IPV6_PREFER_SRC_PUBLIC = 2
+
+
+class GetIpException(Exception):
+    """generic base class for all exceptions raised here"""
+
+
+def detect_ip(kind):
+    """
+    Detect IP address.
+
+    kind can be:
+        IPV4 - returns IPv4 address
+        IPV6_ANY - returns any IPv6 address (no preference)
+        IPV6_PUBLIC - returns public IPv6 address
+        IPV6_TMP - returns temporary IPV6 address (privacy extensions)
+
+    This function either returns an IP address (str) or
+    raises a GetIpException.
+    """
+    assert kind in [IPV4, IPV6_PUBLIC, IPV6_TMP, IPV6_ANY]
+
+    # We create an UDP socket and connect it to a public host.
+    # We query the OS to know what our address is.
+    # No packet will really be sent since we are using UDP.
+    af = socket.AF_INET if kind == IPV4 else socket.AF_INET6
+    s = socket.socket(af, socket.SOCK_DGRAM)
+
+    if kind in [IPV6_PUBLIC, IPV6_TMP, ]:
+        # caller wants some specific kind of IPv6 address (not IPV6_ANY)
+        try:
+            if kind == IPV6_PUBLIC:
+                preference = socket.IPV6_PREFER_SRC_PUBLIC
+            elif kind == IPV6_TMP:
+                preference = socket.IPV6_PREFER_SRC_TMP
+            s.setsockopt(socket.IPPROTO_IPV6,
+                         socket.IPV6_ADDR_PREFERENCES, preference)
+        except socket.error as e:
+            if e.errno == errno.ENOPROTOOPT:
+                raise GetIpException("Kernel doesn't support IPv6 address preference")
+            else:
+                raise GetIpException("Unable to set IPv6 address preference: %s", e)
+
+    try:
+        outside_ip = OUTSIDE_IPV4 if kind == IPV4 else OUTSIDE_IPV6
+        s.connect((outside_ip, 9))
+    except (socket.error, socket.gaierror) as e:
+        raise GetIpException(str(e))
+
+    ip = s.getsockname()[0]
+    return ip
+
+
+if __name__ == '__main__':
+    print("IP v4:", detect_ip(IPV4))
+    print("IP v6 public:", detect_ip(IPV6_PUBLIC))
+    print("IP v6 tmp:", detect_ip(IPV6_TMP))
+    print("IP v6 any:", detect_ip(IPV6_ANY))
+

--- a/dyndnsc/detector/builtin.py
+++ b/dyndnsc/detector/builtin.py
@@ -12,6 +12,7 @@ _builtins = (
     ('dyndnsc.detector.command', 'IPDetector_Command'),
     ('dyndnsc.detector.dns', 'IPDetector_DNS'),
     ('dyndnsc.detector.iface', 'IPDetector_Iface'),
+    ('dyndnsc.detector.socket_ip', 'IPDetector_Socket'),
     ('dyndnsc.detector.rand', 'IPDetector_Random'),
     ('dyndnsc.detector.teredo', 'IPDetector_Teredo'),
     ('dyndnsc.detector.webcheck', 'IPDetectorWebCheck'),

--- a/dyndnsc/detector/socket_ip.py
+++ b/dyndnsc/detector/socket_ip.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+
+import logging
+
+from .base import IPDetector
+from ..common.detect_ip import detect_ip, IPV4, IPV6_PUBLIC, GetIpException
+
+log = logging.getLogger(__name__)
+
+
+class IPDetector_Socket(IPDetector):
+    """
+    IPDetector to detect IPs used by the system to communicate with outside world.
+    """
+    def __init__(self, options=None):
+        """
+        Constructor
+        @param options: dictionary
+
+        available options:
+
+        family: IP address family (default: INET, possible: INET6)
+        """
+        if options is None:
+            options = {}
+        # default options:
+        self.opts = {
+            'family': 'INET',
+        }
+        for k in options.keys():
+            log.debug("%s explicitly got option: %s -> %s",
+                      self.__class__.__name__, k, options[k])
+            self.opts[k] = options[k]
+
+        # ensure address family is understood:
+        if self.opts['family'] not in ('INET', 'INET6'):
+            raise ValueError("Unsupported address family '%s' specified!" %
+                             self.opts['family'])
+
+        super(IPDetector_Socket, self).__init__()
+
+    @staticmethod
+    def names():
+        return ("socket",)
+
+    def can_detect_offline(self):
+        # unsure about this. detector does not really transmit data to outside,
+        # but unsure if it gives the wanted IPs if system is offline
+        return False
+
+    def detect(self):
+        if self.opts['family'] == 'INET6':
+            kind = IPV6_PUBLIC
+        else: # 'INET':
+            kind = IPV4
+        theip = None
+        try:
+            theip = detect_ip(kind)
+        except GetIpException:
+            log.exception("socket detector raised an exception:")
+        self.set_current_value(theip)
+        return theip

--- a/dyndnsc/tests/detector/test_all.py
+++ b/dyndnsc/tests/detector/test_all.py
@@ -129,6 +129,17 @@ class TestIndividualDetectors(unittest.TestCase):
         # unknown address family  must fail construction
         self.assertRaises(ValueError, iface.IPDetector_Iface, {'family': 'bla'})
 
+    def test_socket_detector(self):
+        import dyndnsc.detector.socket_ip as socket_ip
+        NAME = "socket"
+        self.assertTrue(NAME in socket_ip.IPDetector_Socket.names())
+        detector = socket_ip.IPDetector_Socket({'family': 'INET'})
+        self.assertFalse(detector.can_detect_offline())
+        self.assertEqual(None, detector.get_current_value())
+        self.assertTrue(type(detector.detect()) in (type(None), str))
+        # unknown address family  must fail construction
+        self.assertRaises(ValueError, socket_ip.IPDetector_Socket, {'family': 'bla'})
+
     def test_teredo_detector(self):
         import dyndnsc.detector.teredo as teredo
         NAME = "teredo"


### PR DESCRIPTION
the detect_ip lib implements a nice method to find out the IP address that the system uses to talk to the outside world, based on sockets.
for IPv6 this makes much sense for us, especially because we can find out the PUBLIC STATIC IP v6 address (not the privacy enhanced temporary one).
for IPv4 it makes much less sense, as there usually is NAT, so we rather want to find out the router's outside IP, thus webcheck4 is better for that.

Note: If one uses the socket method to determine the public static IPv6 of one system inside a LAN, nsupdate.info can use the prefix of that to compute all other LAN IPv6 addresses from a table that maps interface IDs -> names.
