### PR TITLE
Use proper dyndns-url URLs for nsupdate.info

### DIFF
--- a/dyndnsc/resources/presets.ini
+++ b/dyndnsc/resources/presets.ini
@@ -18,7 +18,7 @@ detector-parser = freedns_afraid
 
 [preset:nsupdate.info:ipv4]
 updater = dyndns2
-updater-url = https://nsupdate.info/nic/update
+updater-url = https://ipv4.nsupdate.info/nic/update
 detector = webcheck4
 detector-family = INET
 detector-url = https://ipv4.nsupdate.info/myip
@@ -27,7 +27,7 @@ detector-parser = plain
 
 [preset:nsupdate.info:ipv6]
 updater = dyndns2
-updater-url = https://nsupdate.info/nic/update
+updater-url = https://ipv6.nsupdate.info/nic/update
 detector = socket
 detector-family = INET6
 


### PR DESCRIPTION
The update URLs for nsupdate.info changed to the prefixed versions (ipv4. , ipv6.).
Therefore the current preset is not working out of the box. Anymore, since dyndnsc is
getting a 401 bad auth response on the former URL.